### PR TITLE
Handle Bol.com returning unix timestamps with milliseconds

### DIFF
--- a/src/Types/ExportOfferCollection.php
+++ b/src/Types/ExportOfferCollection.php
@@ -6,6 +6,7 @@ namespace Rojtjo\Bol\Types;
 
 use DateTimeImmutable;
 use Rojtjo\Bol\Common\TypedCollection;
+use Rojtjo\Bol\Util\Timestamp;
 
 final class ExportOfferCollection extends TypedCollection
 {
@@ -33,7 +34,7 @@ final class ExportOfferCollection extends TypedCollection
                         FulfilmentMethod::from($offer['fulfilmentType']),
                         DeliveryCode::from($offer['fulfilmentDeliveryCode']),
                     ),
-                    new DateTimeImmutable($offer['mutationDateTime']),
+                    Timestamp::parse($offer['mutationDateTime']),
                 ),
                 $payload,
             ),

--- a/src/Types/Order.php
+++ b/src/Types/Order.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rojtjo\Bol\Types;
 
 use DateTimeImmutable;
+use Rojtjo\Bol\Util\Timestamp;
 
 final class Order
 {
@@ -93,7 +94,7 @@ final class Order
                                 $orderItem['additionalServices'] ?? [],
                             ),
                         ),
-                        new DateTimeImmutable($orderItem['latestChangedDateTime'])
+                        Timestamp::parse($orderItem['latestChangedDateTime'])
                     ),
                     $payload['orderItems'],
                 ),

--- a/src/Types/PushMessage.php
+++ b/src/Types/PushMessage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rojtjo\Bol\Types;
 
 use DateTimeImmutable;
+use Rojtjo\Bol\Util\Timestamp;
 
 final class PushMessage
 {
@@ -20,7 +21,7 @@ final class PushMessage
     {
         return new self(
             $payload['retailerId'],
-            new DateTimeImmutable($payload['timeStamp']),
+            Timestamp::parse($payload['timeStamp']),
             new Event(
                 $payload['event']['resource'],
                 $payload['event']['type'],

--- a/src/Types/ReducedOrder.php
+++ b/src/Types/ReducedOrder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rojtjo\Bol\Types;
 
 use DateTimeImmutable;
+use Rojtjo\Bol\Util\Timestamp;
 
 final class ReducedOrder
 {
@@ -34,7 +35,7 @@ final class ReducedOrder
                     quantityShipped: (int) $item['quantityShipped'],
                     quantityCancelled: (int) $item['quantityCancelled'],
                     cancellationRequest: (bool) $item['cancellationRequest'],
-                    latestChangedDateTime: new DateTimeImmutable($item['latestChangedDateTime']),
+                    latestChangedDateTime: Timestamp::parse($item['latestChangedDateTime']),
                 ),
                 $payload['orderItems'] ?? [],
             ),

--- a/src/Util/Timestamp.php
+++ b/src/Util/Timestamp.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rojtjo\Bol\Util;
+
+use DateTimeImmutable;
+
+final class Timestamp
+{
+    public static function parse(string $timestamp): DateTimeImmutable
+    {
+        return self::fromAtom($timestamp)
+            ?? self::fromUnixWithMilliseconds($timestamp)
+            ?? self::fallback($timestamp);
+    }
+
+    private static function fromAtom(string $timestamp): ?DateTimeImmutable
+    {
+        return DateTimeImmutable::createFromFormat(DateTimeImmutable::ATOM, $timestamp)
+            ?: null;
+    }
+
+    private static function fromUnixWithMilliseconds(string $timestamp): ?DateTimeImmutable
+    {
+        $timestamp = substr_replace($timestamp, '.'.substr($timestamp, -3), -3);
+
+        return DateTimeImmutable::createFromFormat('U.u', $timestamp)
+            ?: null;
+    }
+
+    private static function fallback(string $timestamp): DateTimeImmutable
+    {
+        return new DateTimeImmutable($timestamp);
+    }
+}

--- a/src/Util/TimestampTest.php
+++ b/src/Util/TimestampTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rojtjo\Bol\Util;
+
+use PHPUnit\Framework\TestCase;
+
+final class TimestampTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider timestamps
+     */
+    public function parse_timestamp(string $input, string $atom): void
+    {
+        $dt = Timestamp::parse($input);
+
+        $this->assertSame($atom, $dt->format(\DateTimeImmutable::ATOM));
+    }
+
+    public function timestamps(): array
+    {
+        return [
+            'atom format' => ['2025-08-11T07:10:25+00:00', '2025-08-11T07:10:25+00:00'],
+            'unix timestamp with milliseconds' => ['1754896225000', '2025-08-11T07:10:25+00:00'],
+            'date string' => ['2025-08-11', '2025-08-11T00:00:00+00:00'],
+        ];
+    }
+}


### PR DESCRIPTION
It seems that Bol.com started returning unix timestamps with milliseconds. This is not mentioned in their documentation, so I've added support for both the old and the new format. I've also included a fallback option.